### PR TITLE
Removed this.parseInputValue() from getTime function

### DIFF
--- a/dist/bootstrap4-clockpicker.js
+++ b/dist/bootstrap4-clockpicker.js
@@ -863,8 +863,6 @@
 
   // Allow user to get time time as Date object
   ClockPicker.prototype.getTime = function(callback) {
-    this.parseInputValue();
-
     var hours = this.hours;
     if (this.options.twelvehour && hours < 12 && this.amOrPm === "PM") {
       hours += 12;


### PR DESCRIPTION
Parsing input value in getTime function broke picked value when beforeHide or beforeDone callbacks were in use.